### PR TITLE
Content String Improvements

### DIFF
--- a/content/localization/contents.lr
+++ b/content/localization/contents.lr
@@ -10,7 +10,7 @@ title: Localization
 ---
 subtitle: We want Tor to work for everyone in the world, which means a lot of languages.
 ---
-cta: Will you help us to translate?
+cta: Help Us Translate
 ---
 key: 5
 ---

--- a/content/onion-services/contents.lr
+++ b/content/onion-services/contents.lr
@@ -6,7 +6,7 @@ color: primary
 ---
 _template: layout.html
 ---
-title: .onion Services
+title: Onion Services
 ---
 subtitle: Onion services help you and your users defeat surveillance and censorship. Learn how you can deploy onion services.
 ---

--- a/content/relay-operations/contents.lr
+++ b/content/relay-operations/contents.lr
@@ -6,7 +6,7 @@ color: primary
 ---
 _template: layout.html
 ---
-title: Relay operations
+title: Relay Operations
 ---
 subtitle: Relays are the backbone of the Tor network. Help make Tor stronger and faster by running a relay today.
 ---

--- a/content/user-testing/current/contents.lr
+++ b/content/user-testing/current/contents.lr
@@ -10,7 +10,7 @@ _template: layout.html
 ---
 title: Currently Testing Stuffs
 ---
-subtitle: Link to somewhere we csan update more than this webpage, even banners will be tedious if we do testing all the time. We can even oput some thing puilled from there and have it populated here.
+subtitle: Link to somewhere we can update more than this webpage, even banners will be tedious if we do testing all the time. We can even put something pulled from there and have it populated here.
 ---
 key: 1
 ---

--- a/databags/pagenav+en.ini
+++ b/databags/pagenav+en.ini
@@ -20,4 +20,4 @@ label = Localization
 
 [onion-services]
 path = onion-services
-label = .Onion Services
+label = Onion Services

--- a/templates/onion-services.html
+++ b/templates/onion-services.html
@@ -28,7 +28,7 @@
   <div class="row py-5 text-center mx-auto">
     <h2 class="display-4 text-primary text-center mx-auto">{{ _('Onionize any website') }}</h2>
     <p class="text-center">
-      {{ _('There\'s a toolkit that lets you take any existing website and host it as a .onion site. You would wanna do this because .onion sites are more secure than just regular sites. We show you how to use this toolkit and onionize a site.') }}
+      {{ _('There\'s a toolkit that lets you take any existing website and host it as a .onion site. You would want to do this because .onion sites are more secure than just regular sites. We show you how to use this toolkit and onionize a site.') }}
     </p>
   </div>
   <div class="row mx-auto">


### PR DESCRIPTION
1. `.Onion -> Onion`
2. `Relay operations -> Relay Operations` since more consistent with other strings
3. Since it's a call to action I felt a question was less appropriate.
4. `wanna -> want to` since more formal
5. typos fixed :D