### PR TITLE
Fix port number ambiguity and path issue

### DIFF
--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -48,17 +48,18 @@ sudo cp $GOPATH/bin/obfs4proxy /usr/local/bin/
 RunAsDaemon 1
 BridgeRelay 1
 
-# Replace "TODO" with a Tor port of your choice.  This port must be externally
+# Replace "TODO1" with a Tor port of your choice.  This port must be externally
 # reachable.  Avoid port 9001 because it's commonly associated with Tor and
 # censors may be scanning the Internet for this port.
-ORPort TODO
+ORPort TODO1
 
-ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
+ServerTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
 
-# Replace "TODO" with an obfs4 port of your choice.  This port must be
-# externally reachable.  Avoid port 9001 because it's commonly associated with
+# Replace "TODO2" with an obfs4 port of your choice.  This port must be
+# externally reachable and must be different from the one specified for ORPort.
+# Avoid port 9001 because it's commonly associated with
 # Tor and censors may be scanning the Internet for this port.
-ServerTransportListenAddr obfs4 0.0.0.0:TODO
+ServerTransportListenAddr obfs4 0.0.0.0:TODO2
 
 # Local communication port between Tor and obfs4.  Always set this to "auto".
 # "Ext" means "extended", not "external".  Don't try to set a specific port


### PR DESCRIPTION
When I read this I was stumped for a while by the fact that the same name was used for what I believe should be two different values. TODO was used for both the ORPort and the obfs4 port.. I tried to make it clear that these should be two different ports. Also, you install obfs4 into /usr/local/bin but then configured tor to use /usr/bin.

Some issues I was unable to resolve:
1. on CentOS Linux release 7.6.1810 I was unable to install obfs4 using 'go get'.
```
go get gitlab.com/yawning/obfs4.git/obfs4proxy
cd .; git clone https://gitlab.com/yawning/utls /tmp/tmp.HMbPtKs8RV/src/gitlab.com/yawnin/utls.git
error: RPC failed; result=22, HTTP code = 404
fatal: The remote end hung up unexpectedly
package gitlab.com/yawning/utls.git: exit status 128
```

2. On Fedora 30 I was able to install obfs4, but I struggled with selinux. I needed:
```
/sbin/restorecon -v /usr/local/bin/obfs4proxy
Relabeled /usr/local/bin/obfs4proxy from system_u:object_r:tor_exec_t:s0 to system_u:object_r:bin_t:s0
```
and
    `semanage port -a -t tor_port_t -p tcp 4151`
to get things working. I suspect your suggested chcon was ill-advised and resulted in the need for me to run restorecon.