### PR TITLE
Added Fedora Instructions

### DIFF
--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -21,6 +21,12 @@ yum install git golang tor
 zypper install tor go git
 ```
 
+* Fedora:
+
+```
+dnf install git golang tor policycoreutils-python-utils
+```
+
 ### 2. Build obfs4proxy and move it into place.
 
 Heavily outdated versions of git can make `go get` fail, so try upgrading to a more recent git version if you're running into this problem.
@@ -42,7 +48,17 @@ go get gitlab.com/yawning/obfs4.git/obfs4proxy
 sudo cp $GOPATH/bin/obfs4proxy /usr/local/bin/
 ```
 
+* Fedora:
+
+```
+export GOPATH=`mktemp -d`
+go get gitlab.com/yawning/obfs4.git/obfs4proxy
+sudo cp $GOPATH/bin/obfs4proxy /usr/bin/
+```
+
 ### 3. Edit your Tor config file, usually located at `/etc/tor/torrc` and replace its content with:
+
+* CentOS / RHEL / OpenSUSE:
 
 ```
 RunAsDaemon 1
@@ -72,6 +88,36 @@ ContactInfo <address@email.com>
 # Pick a nickname that you like for your bridge.  This is optional.
 Nickname PickANickname
 ```
+* Fedora:
+
+```
+RunAsDaemon 1
+BridgeRelay 1
+
+# Replace "TODO" with a Tor port of your choice.  This port must be externally
+# reachable.  Avoid port 9001 because it's commonly associated with Tor and
+# censors may be scanning the Internet for this port.
+ORPort TODO
+
+ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
+
+# Replace "TODO" with an obfs4 port of your choice.  This port must be
+# externally reachable.  Avoid port 9001 because it's commonly associated with
+# Tor and censors may be scanning the Internet for this port.
+ServerTransportListenAddr obfs4 0.0.0.0:TODO
+
+# Local communication port between Tor and obfs4.  Always set this to "auto".
+# "Ext" means "extended", not "external".  Don't try to set a specific port
+# number, nor listen on 0.0.0.0.
+ExtORPort auto
+
+# Replace "<address@email.com>" with your email address so we can contact you if
+# there are problems with your bridge.  This is optional but encouraged.
+ContactInfo <address@email.com>
+
+# Pick a nickname that you like for your bridge.  This is optional.
+Nickname PickANickname
+```
 
  Don't forget to change the `ORPort`, `ServerTransportListenAddr`, `ContactInfo`, and `Nickname` options.
 
@@ -79,7 +125,17 @@ Nickname PickANickname
 
 ### 4. Restart tor
 
+* CentOS / RHEL / OpenSUSE:
+
 `systemctl restart tor`
+
+* Fedora:
+
+```
+sudo semanage port -a -t tor_port_t -p tcp [desired ORPort number set earlier]
+sudo semanage port -a -t tor_port_t -p tcp [desired ServerTransportListenAddr port number set earlier]
+systemctl restart tor
+```
 
 ### 5. Monitor your logs (usually in your syslog)
 

--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -12,7 +12,7 @@ body:
 
 ```
 yum install epel-release
-yum install git golang tor
+yum install git golang tor policycoreutils-python-utils
 ```
 
 * OpenSUSE:
@@ -129,7 +129,7 @@ Nickname PickANickname
 
 `systemctl restart tor`
 
-* Fedora:
+* Fedora / RHEL / CentOS:
 
 ```
 sudo semanage port -a -t tor_port_t -p tcp [desired ORPort number set earlier]

--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -81,17 +81,16 @@ Nickname PickANickname
 
 ### 4. Restart tor
 
-* CentOS / RHEL / OpenSUSE:
-
-`systemctl restart tor`
-
 * RHEL / CentOS:
 
 ```
 sudo semanage port -a -t tor_port_t -p tcp [desired ORPort number set earlier]
 sudo semanage port -a -t tor_port_t -p tcp [desired ServerTransportListenAddr port number set earlier]
-systemctl restart tor
 ```
+
+* CentOS / RHEL / OpenSUSE:
+
+`systemctl restart tor`
 
 ### 5. Monitor your logs (usually in your syslog)
 

--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -21,12 +21,6 @@ yum install git golang tor policycoreutils-python-utils
 zypper install tor go git
 ```
 
-* Fedora:
-
-```
-dnf install git golang tor policycoreutils-python-utils
-```
-
 ### 2. Build obfs4proxy and move it into place.
 
 Heavily outdated versions of git can make `go get` fail, so try upgrading to a more recent git version if you're running into this problem.
@@ -46,14 +40,6 @@ chcon --reference=/usr/bin/tor /usr/local/bin/obfs4proxy
 export GOPATH=`mktemp -d`
 go get gitlab.com/yawning/obfs4.git/obfs4proxy
 sudo cp $GOPATH/bin/obfs4proxy /usr/local/bin/
-```
-
-* Fedora:
-
-```
-export GOPATH=`mktemp -d`
-go get gitlab.com/yawning/obfs4.git/obfs4proxy
-sudo cp $GOPATH/bin/obfs4proxy /usr/bin/
 ```
 
 ### 3. Edit your Tor config file, usually located at `/etc/tor/torrc` and replace its content with:
@@ -88,36 +74,6 @@ ContactInfo <address@email.com>
 # Pick a nickname that you like for your bridge.  This is optional.
 Nickname PickANickname
 ```
-* Fedora:
-
-```
-RunAsDaemon 1
-BridgeRelay 1
-
-# Replace "TODO" with a Tor port of your choice.  This port must be externally
-# reachable.  Avoid port 9001 because it's commonly associated with Tor and
-# censors may be scanning the Internet for this port.
-ORPort TODO
-
-ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
-
-# Replace "TODO" with an obfs4 port of your choice.  This port must be
-# externally reachable.  Avoid port 9001 because it's commonly associated with
-# Tor and censors may be scanning the Internet for this port.
-ServerTransportListenAddr obfs4 0.0.0.0:TODO
-
-# Local communication port between Tor and obfs4.  Always set this to "auto".
-# "Ext" means "extended", not "external".  Don't try to set a specific port
-# number, nor listen on 0.0.0.0.
-ExtORPort auto
-
-# Replace "<address@email.com>" with your email address so we can contact you if
-# there are problems with your bridge.  This is optional but encouraged.
-ContactInfo <address@email.com>
-
-# Pick a nickname that you like for your bridge.  This is optional.
-Nickname PickANickname
-```
 
  Don't forget to change the `ORPort`, `ServerTransportListenAddr`, `ContactInfo`, and `Nickname` options.
 
@@ -129,7 +85,7 @@ Nickname PickANickname
 
 `systemctl restart tor`
 
-* Fedora / RHEL / CentOS:
+* RHEL / CentOS:
 
 ```
 sudo semanage port -a -t tor_port_t -p tcp [desired ORPort number set earlier]


### PR DESCRIPTION
So this is what I needed to do in order to get my fedora server up and running as a bridge, and I've added these instructions as if these problems only affect Fedora users, but I would be surprised if that's the case, because the alternative ports that are encouraged in this guide for ORPort and ServerTransportListenAddr are exactly what selinux is supposed to stop. Because of that, I'd imagine that this would function the same on CentOS SUSE and RHEL.

 As for why the fedora instructions install the executable into normal bin, that's because you run into selinux problems there too when it's in /usr/local/bin , but problems that were more complicated than my tiny selinux knowledge can deal with.

policycoreutils-python-utils is needed for semanage.