### PR TITLE
Change small typo

### DIFF
--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -8,7 +8,7 @@ body:
 
 ### 1. Install tor and dependencies
 
-* Redhat / RHEL:
+* CentOS / RHEL:
 
 ```
 yum install epel-release


### PR DESCRIPTION
I'm still investigating whether or not you run into the same problems that I did on Fedora in other selinux enabled systems (CentOS/RHEL). But I noticed this little thing as well, so I figured I might as well change it