### PR TITLE
Fix OpenBSD tor bridge instructions (data dir + logging perms)

### DIFF
--- a/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
@@ -26,7 +26,7 @@ BridgeRelay 1
 # censors may be scanning the Internet for this port.
 ORPort TODO1
 
-ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
+ServerTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
 
 # Replace "TODO2" with an obfs4 port of your choice.  This port must be
 # externally reachable and must be different from the one specified for ORPort.

--- a/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
@@ -49,19 +49,27 @@ Nickname PickANickname
 Log notice file /var/log/tor/notices.log
 
 User _tor
+DataDirectory /var/tor
 ```
 
 Don't forget to change the `ORPort`, `ServerTransportListenAddr`, `ContactInfo`, and `Nickname` options. 
 
 * Note that both Tor's OR port and its obfs4 port must be reachable. If your bridge is behind a firewall or NAT, make sure to open both ports. You can use [our reachability test](https://bridges.torproject.org/scan/) to see if your obfs4 port is reachable from the Internet.
 
-### 3. Start the tor daemon and make sure it starts at boot: 
+### 3. Create the tor log directory and give it the correct permissions:
+
+```
+mkdir /var/log/tor
+chown _tor /var/log/tor
+```
+
+### 4. Start the tor daemon and make sure it starts at boot:
 
 ```
 rcctl enable tor
 rcctl start tor
 ```
-### 4. Monitor your logs
+### 5. Monitor your logs
 
 To confirm your bridge is running with no issues, you should see something like this  (`/var/log/tor/notices.log`): 
 
@@ -75,7 +83,7 @@ To confirm your bridge is running with no issues, you should see something like 
 [notice] Self-testing indicates your ORPort is reachable from the outside. Excellent. Publishing server descriptor.
 ```
 
-### 5. Final notes
+### 6. Final notes
 
 If you are having troubles setting up your bridge, have a look at [our help
 section](https://community.torproject.org/relay/getting-help/). If


### PR DESCRIPTION
Hi There,

This is a PR to update the OpenBSD Tor bridge setup instructions with a few additional steps I had to perform to get it working. Using the existing instructions on a fresh installation of OpenBSD 6.5, running `rcctl start tor` gave me `tor(failed)` and the service failed to start.

The main errors when using the existing instructions I ran into:

```
[warn] Directory /root/.tor cannot be read: Permission denied
```
Tor was, by default, trying to write its data to `/root/.tor`. Since the existing instructions configure tor to launch as user `_tor`, this error makes sense since `_tor` doesn't have any access to /root by default. I fixed this by specifying `DataDirectory /var/tor`, which seems to be created by default after installing the `tor` package. It also is owned by `_tor` by default so as far as I can tell, this should be the default data dir for tor (correct me if I'm wrong).

```
[warn] Couldn't open file for 'Log notice file /var/log/tor/notices.log': Permission denied
```
`/var/log/tor` doesn't exist by default. So I included a step to create the directory and `chown` the user to `_tor` to enable tor logging.

Also, I noticed the instructions say to point Tor to use obfs4proxy at `/usr/bin/obfs4proxy`, but on my system, when I ran `pkg_add obfs4proxy`, it seemed to install the obfs4proxy binary at `/usr/local/bin`, so I changed torrc to use that directory and it seemed to work.

After this, tor seemed to launch without any errors and the log shows normal startup/tor output.