### PR TITLE
Improve Onion Services Terminology Consistency

### DIFF
--- a/content/onion-services/setup/contents.lr
+++ b/content/onion-services/setup/contents.lr
@@ -8,9 +8,9 @@ image: cloud-upload-alt
 ---
 _template: layout.html
 ---
-title: Set up your .onion Service
+title: Set up your Onion Service
 ---
-subtitle: Learn how to set up a .onion of your very own.
+subtitle: Learn how to set up a .onion site of your very own.
 ---
 key: 1
 ---

--- a/databags/pagenav+en.ini
+++ b/databags/pagenav+en.ini
@@ -16,4 +16,4 @@ label = Relay Operations
 
 [onion-services]
 path = onion-services
-label = .Onion Services
+label = Onion Services


### PR DESCRIPTION
Improves https://dip.torproject.org/web/community/issues/60

I wasn't sure if the correct pronunciation of .onion is onion or _dot onion_ since that affects whether it's an .onion or a .onion so that's unchanged.

Followed the terminology guidelines specified on the linked dip issue.