### PR TITLE
update *BSD setup guides for middle/guard relays

### DIFF
--- a/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
@@ -1,0 +1,99 @@
+_model: page
+---
+color: primary
+---
+title: DragonflyBSD
+---
+body:
+
+# 1. Bootstrap `pkg`
+
+DragonFlyBSD's daily snapshots and releases (starting with 3.4) come with `pkg` already installed. Upgrades from earlier releases, however, will not have it.
+
+If `pkg` is missing on the system for any reason, it can be quickly bootstrapped without having to build it from source or even having **DPorts** installed:
+
+```
+cd /usr
+make pkg-bootstrap
+rehash
+pkg-static install -y pkg
+rehash
+```
+
+### 1.1. Recommended Steps to Setup `pkg`
+
+Here, it will be similar to what we have on a **FreeBSD** system, and we are going to use HTTPS to fetch our packages, and updates - so here we also need an extra package to help us out (ca_root_nss).
+
+Installing the `ca_root_nss` package:
+
+```
+pkg install ca_root_nss
+```
+
+For fresh installations, the file `/usr/local/etc/pkg/repos/df-latest.conf.sample` is copied to `/usr/local/etc/pkg/repos/df-latest`. The files ending in the ".sample" extension are ignored; pkg(8) only reads files that end in ".conf" and it will read as many as it finds.
+
+DragonflyBSD has 2 packages repositories:
+
+  - Avalon (mirror-master.dragonflybsd.org);
+  - Wolfpond (pkg.wolfpond.org).
+
+We can simply edit the **URL** used to point out the repositories on `/usr/local/etc/pkg/repos/df-latest` and that's it! Remember to use **pkg+https://** for Avalon.
+
+After applying all these changes, we update the packages list again and try to check if there's already a new update to apply:
+
+```
+pkg update -f
+pkg upgrade -y -f
+```
+
+# 2. Install `tor` DragonflyBSD's Package
+
+Here we can choose to install the latest stable version, like:
+
+```
+pkg install tor
+```
+
+  ... or install an alpha release:
+
+
+```
+pkg install tor-devel
+```
+
+# 3. Configure `/usr/local/etc/tor/torrc`
+
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
+
+```
+Nickname    myBSDRelay    # Change your relay's nickname to something you like
+ContactInfo your@email    # Please write your email address and be aware that it will be published
+ORPort      443           # You might want to use/try a different port, should you want to
+ExitRelay   0
+SocksPort   0
+Log notice  syslog
+```
+
+# 4. Start `tor`:
+
+Here we set `tor` to start at boot time and use the setuid feature, in order to bind to lower ports like 443 (the daemon itself will still run as a regular non-privileged user).
+
+```
+echo "tor_setuid=YES" >> /etc/rc.conf
+echo "tor_enable=YES" >> /etc/rc.conf
+service tor start
+```
+
+# 5. Final Notes
+
+If you are having troubles setting up your relay, have a look at our [help section](/relay/getting-help/). If your relay is now running, check out the [post-install](/relay/setup/post-install/) notes.
+---
+html: two-columns-page.html
+---
+key: 2
+---
+section: Middle/Guard relay
+---
+section_id: relay-operations
+---
+subtitle: How to deploy a Middle/Guard relay on DragonflyBSD

--- a/content/relay-operations/technical-setup/guard/freebsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/freebsd/contents.lr
@@ -6,68 +6,102 @@ title: FreeBSD
 ---
 body:
 
-# 1. Enable Automatic Software Updates
+# 1. Enable Automatic Updates for Packages
 
 One of the most imported things to keeps your relay secure is to install security updates timely and ideally automatically so you can not forget about it. Follow the instructions to enable [automatic software updates](updates) for your operating system.
 
-# 2. Install the tor package
+# 2. Bootstrap `pkg`
 
-`pkg install tor ca_root_nss`
+This article considers we have already a base installation of FreeBSD running, and only the base system (here, we are running 12.0-RELEASE). That means we do not have any packages installed neither the `pkg` packages manager itself (there's no `sudo` available - we are running commands as root).
 
-or for alpha releases:
-
-`pkg install tor-devel ca_root_nss`
-
-# 3. Put the configuration file `/usr/local/etc/tor/torrc` in place
+To bootstrap and install `pkg` we should run the following command:
 
 ```
-#change the nickname "myNiceRelay" to a name that you like
-Nickname myNiceRelay
-ORPort 9001
-ExitRelay 0
-SocksPort 0
-# Change the email address bellow and be aware that it will be published
-ContactInfo tor-operator@your-emailaddress-domain
-Log notice syslog
+pkg bootstrap
+pkg update -f
 ```
 
-# 4. Ensure that the `random_id` sysctl setting is enabled:
+### 2.1. Recommended Steps to Setup `pkg`
+
+To follow upstream updates in a "faster way" we recommend changing the 'quarterly' branch used by `pkg` to its 'latest' branch.
+
+One additional step is to prefer using HTTPS to fetch our packages, and updates - so here we also need an extra package to help us out (ca_root_nss).
+
+Installing the `ca_root_nss` package:
+
+```
+pkg install ca_root_nss
+```
+
+We are keeping the original setting used by `pkg` but setting a new one that will override it, so we set up a new directory and than create a configuration file to override what we need. This configuration file will be `/usr/local/etc/pkg/repos/FreeBSD.conf`.
+
+Creating the new directory:
+
+```
+mkdir -p /usr/local/etc/pkg/repos
+```
+
+This is how the new configuration file `/usr/local/etc/pkg/repos/FreeBSD.conf` must look like:
+
+```
+FreeBSD: {
+  url: pkg+https://pkg.freebsd.org/${ABI}/latest
+}
+```
+
+After applying all these changes, we update the packages list again and try to check if there's already a new update to apply:
+
+```
+pkg update -f
+pkg upgrade -y -f
+```
+
+# 3. Install `tor` FreeBSD's Package
+
+Here we can choose to install the latest stable version, like:
+
+```
+pkg install tor
+```
+
+  ... or install an alpha release:
+
+
+```
+pkg install tor-devel
+```
+
+# 4. Configure `/usr/local/etc/tor/torrc`
+
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
+
+```
+Nickname    myBSDRelay    # Change your relay's nickname to something you like
+ContactInfo your@email    # Please write your email address and be aware that it will be published
+ORPort      443           # You might want to use/try a different port, should you want to
+ExitRelay   0
+SocksPort   0
+Log notice  syslog
+```
+
+# 5. Ensure `net.inet.ip.random_id` is enabled:
 
 ```
 echo "net.inet.ip.random_id=1" >> /etc/sysctl.conf
 sysctl net.inet.ip.random_id=1
 ```
 
-# 5. Start the tor daemon and make sure it starts at boot:
+# 6. Start `tor`:
+
+Here we set `tor` to start at boot time and use the setuid feature, in order to bind to lower ports like 443 (the daemon itself will still run as a regular non-privileged user).
 
 ```
+sysrc tor_setuid=YES
 sysrc tor_enable=YES
 service tor start
 ```
 
-### Optional but recommended
-
-To get package updates faster after they have been build it is best to switch from the "quarterly" with "latest" repository.
-
-Create the following folder:
-
-`mkdir -p /usr/local/etc/pkg/repos`
-
-and create the file `/usr/local/etc/pkg/repos/FreeBSD.conf` with the following content:
-
-```
-FreeBSD: { enabled: no }
-
-FreeBSDlatest: {
-  url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest",
-  mirror_type: "srv",
-  signature_type: "fingerprints",
-  fingerprints: "/usr/share/keys/pkg",
-  enabled: yes
-}
-```
-
-# 6. Final notes
+# 7. Final Notes
 
 If you are having troubles setting up your relay, have a look at our [help section](/relay/getting-help/). If your relay is now running, check out the [post-install](/relay/setup/post-install/) notes.
 ---
@@ -79,4 +113,4 @@ section: Middle/Guard relay
 ---
 section_id: relay-operations
 ---
-subtitle: How to deploy a middle/Guard relay on FreeBSD
+subtitle: How to deploy a Middle/Guard relay on FreeBSD

--- a/content/relay-operations/technical-setup/guard/netbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/netbsd/contents.lr
@@ -1,0 +1,51 @@
+_model: page
+---
+color: primary
+---
+title: NetBSD
+---
+body:
+
+# 1. Setup `pkg_add`
+
+```
+echo "PKG_PATH=http://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All" > /etc/pkg_install.conf
+```
+
+# 2. Install `tor` NetBSD's package
+
+```
+pkg_add tor
+```
+
+# 3. Configure `/usr/pkg/etc/tor/torrc`
+
+```
+Nickname    myBSDRelay    # Change your relay's nickname to something you like
+ContactInfo your@email    # Please write your email address and be aware that it will be published
+ORPort      443           # You might want to use/try a different port, should you want to
+ExitRelay   0
+SocksPort   0
+Log notice  syslog
+```
+
+# 6. Start `tor`:
+
+Here we set `tor` to start during boot and call it for the first time:
+
+```
+ln -sf /usr/pkg/share/examples/rc.d/tor /etc/rc.d/tor
+echo "tor=YES" >> /etc/rc.conf
+/etc/rc.d/tor start
+```
+
+---
+html: two-columns-page.html
+---
+key: 2
+---
+section: Middle/Guard relay
+---
+section_id: relay-operations
+---
+subtitle: How to deploy a Middle/Guard relay on NetBSD

--- a/content/relay-operations/technical-setup/guard/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/openbsd/contents.lr
@@ -59,8 +59,8 @@ By default, OpenBSD maintains a rather low limit on the maximum number of open f
 Append the following section to `/etc/login.conf`:
 
 ```
-tor:\
-    :openfiles-max=13500:\
+tor:
+    :openfiles-max=13500:
     :tc=daemon:
 ```
 

--- a/content/relay-operations/technical-setup/guard/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/openbsd/contents.lr
@@ -1,0 +1,94 @@
+_model: page
+---
+color: primary
+---
+title: OpenBSD
+---
+body:
+
+# 1. Install `tor` OpenBSD's Package
+
+Recent OpenBSD systems, like 6.5/amd64, already have the repository configured on `/etc/installurl` so we do not need to bother changing it.
+
+Should that's not your case, please adjust the `installurl` configuration file like this:
+
+```
+echo "https://cdn.openbsd.org/pub/OpenBSD" > /etc/installurl
+```
+
+Proceed with `pkg_add` to install the package:
+
+```
+pkg_add tor
+```
+
+### 2.1. Recommended Steps to Install `tor` on OpenBSD
+
+If you want to install a newer version of the `tor` OpenBSD's package, you can use M:Tier's binary packages:
+
+```
+ftp https://stable.mtier.org/openup
+```
+
+Right after fetching `openup` you can run it to sync M:Tier's repository and update your packages; it's an alternative to `pkg_add -u`.
+
+Here is how you proceed with these steps:
+
+```
+openup
+```
+
+# 3. Configure `/etc/tor/torrc`
+
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
+
+```
+Nickname    myBSDRelay    # Change your relay's nickname to something you like
+ContactInfo your@email    # Please write your email address and be aware that it will be published
+ORPort      443           # You might want to use/try a different port, should you want to
+ExitRelay   0
+SocksPort   0
+Log notice  syslog
+User        _tor
+```
+
+# 4. Change `openfiles-max` and `maxfiles` Tweaks
+
+By default, OpenBSD maintains a rather low limit on the maximum number of open files for a process. For a daemon such as Tor's, that opens a connection to each and every other relay (currently around 7000 relays), these limits should be raised.
+
+Append the following section to `/etc/login.conf`:
+
+```
+tor:\
+    :openfiles-max=13500:\
+    :tc=daemon:
+```
+
+OpenBSD also stores a kernel-level file descriptor limit in the sysctl variable `kern.maxfiles`.
+
+Increase it from the default of 7030 to 16000:
+
+```
+echo "kern.maxfiles=16000" >> /etc/sysctl.conf
+sysctl kern.maxfiles=16000
+```
+
+# 6. Start `tor`:
+
+Here we set `tor` to start during boot and call it for the first time:
+
+```
+rcctl enable tor
+rcctl start tor
+```
+
+---
+html: two-columns-page.html
+---
+key: 2
+---
+section: Middle/Guard relay
+---
+section_id: relay-operations
+---
+subtitle: How to deploy a Middle/Guard relay on OpenBSD


### PR DESCRIPTION
**DragonflyBSD**
  - mention the `pkg`'s bootstrap steps;
  - comment about using _HTTPS_ to fetch packages;
  - cover the use of packages, but not **DPorts**.

**FreeBSD**
  - ensure we cover also `pkg`'s bootstrap (for vanilla systems w/o any available package);
  - track the '_latest_' branch used by `pkg` to get more frequent packages updates;
  - use _HTTPS://_ on the repository URL (needs extra package, `ca_root_nss`);
  - cover starting our daemon on port 443, but still as '**_tor**' non-root user.

**OpenBSD**
  - recommend using more recent package, from M:Tier;
  - cover the use of `openup` to update packages;
  - tune system's limits to operate a fine relay (fix trac ticket 27489 [0]).

**NetBSD**
  - mirror what we have on trac already as `wiki/TorRelayGuide/NetBSD`

[0] https://trac.torproject.org/projects/tor/ticket/27489