### PR TITLE
Changed unordered list to ordered list in instructions.

### DIFF
--- a/content/localization/becoming-tor-translator/contents.lr
+++ b/content/localization/becoming-tor-translator/contents.lr
@@ -29,19 +29,19 @@ In order to begin contributing you will have to sign up with Transifex. Here's a
 
 # Signing Up On Transifex
 
-- Head over to the [Transifex signup page](https://transifex.com/signup/).
+1. Head over to the [Transifex signup page](https://transifex.com/signup/).
   Enter your information into the fields and click the 'Sign Up' button:
 ![Sign up to Transifex](/static/images/localization/tr1.png)
-- Fill out the next page with your name and select "Localization" and "Translator" from the drop-down menus:
+1. Fill out the next page with your name and select "Localization" and "Translator" from the drop-down menus:
 ![Fill out details](/static/images/localization/tr2.png)
-- On the next page, select 'Join an existing project' and continue.
-- On the next page, select the languages you speak from the drop-down menu and continue.
-- You are now signed up! Go to the [Tor Transifex page](https://www.transifex.com/otf/torproject/).
-- Click the blue 'Join Team' button on the far right:
+1. On the next page, select 'Join an existing project' and continue.
+1. On the next page, select the languages you speak from the drop-down menu and continue.
+1. You are now signed up! Go to the [Tor Transifex page](https://www.transifex.com/otf/torproject/).
+1. Click the blue 'Join Team' button on the far right:
 ![Join Team](/static/images/localization/tr3.png)
-- Select the language you would like to translate from the dropdown menu:
+1. Select the language you would like to translate from the dropdown menu:
 ![Choose Language](/static/images/localization/tr4.png)
-- A notification will now show up on the top of the page like so:
+1. A notification will now show up on the top of the page like so:
 ![Request Submitted](/static/images/localization/tr5.png)
 
 After your membership is approved, you're ready to begin. 


### PR DESCRIPTION
The steps followed to sign up on Transifex to become a Tor translator would be nice to be an ordered list, so that the reader follows them chronologically.