### PR TITLE
(WIP) Relay guard instructions consistency

### DIFF
--- a/content/relay-operations/technical-setup/guard/centosrhel/contents.lr
+++ b/content/relay-operations/technical-setup/guard/centosrhel/contents.lr
@@ -16,22 +16,22 @@ To install `tor` package on CentOS/RHEL, you need to install the [EPEL](https://
 
 `yum install epel-release`
 
-# 3. Install the tor package and verify the EPEL signing key
+# 3. Install the `tor` package and verify the EPEL signing key
 
 `yum install tor`
 
 When you install the first package from the EPEL repository you will be asked about verifying the EPEL GPG signing key. Please ensure the key matches with the one available on the [Fedora Project website](https://getfedora.org/keys/).
 
-# 4. Put the tor configuration file `/etc/tor/torrc` in place
+# 4. Configure `/etc/tor/torrc`
+
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-#change the nickname "myNiceRelay" to a name that you like
-Nickname myNiceRelay
-ORPort 9001
-SocksPort 0
-ExitRelay 0
-# Change the email address bellow and be aware that it will be published
-ContactInfo tor-operator@your-emailaddress-domain
+Nickname    myNiceRelay   # Change the nickname "myNiceRelay" to a name that you like
+ORPort      9001
+SocksPort   0
+ExitRelay   0
+ContactInfo your@email    # Please write your email address and be aware that it will be published
 ```
 
 # 5. Enable and start your Tor relay

--- a/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
+++ b/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
@@ -14,30 +14,26 @@ One of the most imported things to keeps your relay secure is to install securit
 
 Enable the Torproject package repository by following the instructions **[here](https://support.torproject.org/apt/tor-deb-repo/)**.
 
-# 3. Package Installation
-
-Install the `tor` package:
+# 3. Install the `tor` package:
 
 `apt update && apt install tor`
 
-# 4. Configuration File
+# 4. Configure `/etc/tor/torrc`
 
-Put the configuration file `/etc/tor/torrc` in place:
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-#change the nickname "myNiceRelay" to a name that you like
-Nickname myNiceRelay
-ORPort 443
-ExitRelay 0
-SocksPort 0
+Nickname      myNiceRelay   # Change the nickname "myNiceRelay" to a name that you like
+ORPort        443           # You might want to use/try a different port, should you want to
+ExitRelay     0
+SocksPort     0
 ControlSocket 0
-# Change the email address bellow and be aware that it will be published
-ContactInfo tor-operator@your-emailaddress-domain
+ContactInfo your@email      # Please write your email address and be aware that it will be published
 ```
 
 # 5. Restart the Service
 
-Restart the tor daemon so your configuration changes take effect:
+Restart the `tor` daemon so your configuration changes take effect:
 
 `systemctl restart tor@default`
 

--- a/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
@@ -66,7 +66,7 @@ pkg install tor-devel
 This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-Nickname    myBSDRelay    # Change your relay's nickname to something you like
+Nickname    myBSDRelay    # Change the nickname "myNiceRelay" to a name that you like
 ContactInfo your@email    # Please write your email address and be aware that it will be published
 ORPort      443           # You might want to use/try a different port, should you want to
 ExitRelay   0

--- a/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/dragonflybsd/contents.lr
@@ -6,7 +6,11 @@ title: DragonflyBSD
 ---
 body:
 
-# 1. Bootstrap `pkg`
+# 1. Enable Automatic Software Updates
+
+One of the most imported things to keeps your relay secure is to install security updates timely and ideally automatically so you can not forget about it. Follow the instructions to enable [automatic software updates](https://community.torproject.org/relay/setup/guard/freebsd/updates/) for your operating system.
+
+# 2. Bootstrap `pkg`
 
 DragonFlyBSD's daily snapshots and releases (starting with 3.4) come with `pkg` already installed. Upgrades from earlier releases, however, will not have it.
 
@@ -20,7 +24,7 @@ pkg-static install -y pkg
 rehash
 ```
 
-### 1.1. Recommended Steps to Setup `pkg`
+### 2.1. Recommended Steps to Setup `pkg`
 
 Here, it will be similar to what we have on a **FreeBSD** system, and we are going to use HTTPS to fetch our packages, and updates - so here we also need an extra package to help us out (ca_root_nss).
 
@@ -46,7 +50,7 @@ pkg update -f
 pkg upgrade -y -f
 ```
 
-# 2. Install `tor` DragonflyBSD's Package
+# 3. Install `tor` DragonflyBSD's Package
 
 Here we can choose to install the latest stable version, like:
 
@@ -61,7 +65,7 @@ pkg install tor
 pkg install tor-devel
 ```
 
-# 3. Configure `/usr/local/etc/tor/torrc`
+# 4. Configure `/usr/local/etc/tor/torrc`
 
 This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
@@ -74,7 +78,7 @@ SocksPort   0
 Log notice  syslog
 ```
 
-# 4. Start `tor`:
+# 5. Start `tor`:
 
 Here we set `tor` to start at boot time and use the setuid feature, in order to bind to lower ports like 443 (the daemon itself will still run as a regular non-privileged user).
 
@@ -84,7 +88,7 @@ echo "tor_enable=YES" >> /etc/rc.conf
 service tor start
 ```
 
-# 5. Final Notes
+# 6. Final Notes
 
 If you are having troubles setting up your relay, have a look at our [help section](/relay/getting-help/). If your relay is now running, check out the [post-install](/relay/setup/post-install/) notes.
 ---

--- a/content/relay-operations/technical-setup/guard/fedora/contents.lr
+++ b/content/relay-operations/technical-setup/guard/fedora/contents.lr
@@ -10,22 +10,22 @@ body:
 
 One of the most imported things to keeps your relay secure is to install security updates timely and ideally automatically so you can not forget about it. Follow the instructions to enable [automatic software updates](updates) for your operating system.
 
-# 2.  Install the tor package
+# 2.  Install the `tor` package
 
 `dnf install tor`
 
-# 3. Put the tor configuration file `/etc/tor/torrc` in place
+# 3. Configure `/etc/tor/torrc` 
+
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-#change the nickname "myNiceRelay" to a name that you like
-Nickname myNiceRelay
-ORPort 9001
-ExitRelay 0
-# Change the email address bellow and be aware that it will be published
-ContactInfo tor-operator@your-emailaddress-domain
+Nickname    myNiceRelay   # Change the nickname "myNiceRelay" to a name that you like
+ORPort      9001
+ExitRelay   0
+ContactInfo your@email    # Please write your email address and be aware that it will be published
 ```
 
-# 4. Start the tor daemon and make sure it starts at boot
+# 4. Start the `tor` daemon and make sure it starts at boot
 
 ```
 systemctl enable tor

--- a/content/relay-operations/technical-setup/guard/freebsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/freebsd/contents.lr
@@ -6,7 +6,7 @@ title: FreeBSD
 ---
 body:
 
-# 1. Enable Automatic Updates for Packages
+# 1. Enable Automatic Software Updates
 
 One of the most imported things to keeps your relay secure is to install security updates timely and ideally automatically so you can not forget about it. Follow the instructions to enable [automatic software updates](updates) for your operating system.
 
@@ -76,7 +76,7 @@ pkg install tor-devel
 This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-Nickname    myBSDRelay    # Change your relay's nickname to something you like
+Nickname    myBSDRelay    # Change the nickname "myNiceRelay" to a name that you like
 ContactInfo your@email    # Please write your email address and be aware that it will be published
 ORPort      443           # You might want to use/try a different port, should you want to
 ExitRelay   0

--- a/content/relay-operations/technical-setup/guard/netbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/netbsd/contents.lr
@@ -20,8 +20,10 @@ pkg_add tor
 
 # 3. Configure `/usr/pkg/etc/tor/torrc`
 
+This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
+
 ```
-Nickname    myBSDRelay    # Change your relay's nickname to something you like
+Nickname    myNiceRelay   # Change the nickname "myNiceRelay" to a name that you like
 ContactInfo your@email    # Please write your email address and be aware that it will be published
 ORPort      443           # You might want to use/try a different port, should you want to
 ExitRelay   0

--- a/content/relay-operations/technical-setup/guard/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/openbsd/contents.lr
@@ -6,7 +6,7 @@ title: OpenBSD
 ---
 body:
 
-# 1. Install `tor` OpenBSD's Package.
+# 1. Install `tor` OpenBSD's Package
 
 Recent OpenBSD systems, like 6.5/amd64, already have the repository configured on `/etc/installurl` so we do not need to bother changing it.
 
@@ -22,7 +22,7 @@ Proceed with `pkg_add` to install the package:
 pkg_add tor
 ```
 
-### 2.1. Recommended Steps to Install `tor` on OpenBSD
+### 2.1. Recommended steps to install `tor` on OpenBSD
 
 If you want to install a newer version of the `tor` OpenBSD's package, you can use M:Tier's binary packages:
 

--- a/content/relay-operations/technical-setup/guard/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/guard/openbsd/contents.lr
@@ -6,7 +6,7 @@ title: OpenBSD
 ---
 body:
 
-# 1. Install `tor` OpenBSD's Package
+# 1. Install `tor` OpenBSD's Package.
 
 Recent OpenBSD systems, like 6.5/amd64, already have the repository configured on `/etc/installurl` so we do not need to bother changing it.
 
@@ -43,7 +43,7 @@ openup
 This is a very simple version of the `torrc` configuration file in order to run a Middle/Guard relay on the Tor network:
 
 ```
-Nickname    myBSDRelay    # Change your relay's nickname to something you like
+Nickname    myNiceRelay   # Change the nickname "myNiceRelay" to a name that you like
 ContactInfo your@email    # Please write your email address and be aware that it will be published
 ORPort      443           # You might want to use/try a different port, should you want to
 ExitRelay   0


### PR DESCRIPTION
Fixing this issue:
https://dip.torproject.org/torproject/web/community/issues/102

- [x]  torrc example must be (almost) the same configuration
- [ ] Must include how to keep update your relay
- [x] Step by step instructions should use the same words