### PR TITLE
update become-translator link

### DIFF
--- a/content/localization/translation-problem/contents.lr
+++ b/content/localization/translation-problem/contents.lr
@@ -18,7 +18,7 @@ body:
 
 ### Reporting an error with a translation
 
-* If you are already a [Tor translator](becoming-tor-translator), you can simply find the string and fix it in [transifex](https://www.transifex.com/otf/torproject/).
+* If you are already a [Tor translator](https://community.torproject.org/localization/becoming-tor-translator/), you can simply find the string and fix it in [transifex](https://www.transifex.com/otf/torproject/).
 * If you don't know how to find the string to fix, you can [open a ticket on our Bugtracker](https://support.torproject.org/misc/bug-or-feedback/), under the **Community/Translations** component.
 * You can report such issues on [irc](https://webchat.oftc.net/), on the #tor-l10n channel (you may need to be registered to log in).
 * You can send an email to the [tor localization mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-l10n).

--- a/content/localization/translation-problem/contents.lr
+++ b/content/localization/translation-problem/contents.lr
@@ -18,7 +18,7 @@ body:
 
 ### Reporting an error with a translation
 
-* If you are already a [Tor translator](https://community.torproject.org/localization/becoming-tor-translator/), you can simply find the string and fix it in [transifex](https://www.transifex.com/otf/torproject/).
+* If you are already a [Tor translator](/becoming-tor-translator), you can simply find the string and fix it in [transifex](https://www.transifex.com/otf/torproject/).
 * If you don't know how to find the string to fix, you can [open a ticket on our Bugtracker](https://support.torproject.org/misc/bug-or-feedback/), under the **Community/Translations** component.
 * You can report such issues on [irc](https://webchat.oftc.net/), on the #tor-l10n channel (you may need to be registered to log in).
 * You can send an email to the [tor localization mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-l10n).


### PR DESCRIPTION
This is a different issue that I found while trying to fix this one (https://dip.torproject.org/torproject/web/community/issues/100#note_10073 - which seems to be fixed already - all titles are centered). 

The link "tor translator" on the first bullet point of the main paragraph was broken, and I added the "becoming a tor translator" link instead, I'm not sure if this is the right way of doing it but I'm open to suggestions and I'd love to learn more!

This is my first time contributing ;) 