### PR TITLE
[Fedora instructions] Use system package obfs4

### DIFF
--- a/content/relay-operations/technical-setup/bridge/fedora/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/fedora/contents.lr
@@ -9,22 +9,10 @@ body:
 ### 1. Install tor and dependencies
 
 ```
-dnf install git golang tor policycoreutils-python-utils
+dnf install tor obfs4 policycoreutils-python-utils
 ```
 
-### 2. Build obfs4proxy and move it into place.
-
-```
-export GOPATH=`mktemp -d`
-go get gitlab.com/yawning/obfs4.git/obfs4proxy
-sudo cp $GOPATH/bin/obfs4proxy /usr/local/bin/
-```
-And tell selinux to allow Tor to use obfs4proxy:
-```
-/sbin/restorecon -v /usr/local/bin/obfs4proxy
-```
-
-### 3. Edit your Tor config file, usually located at `/etc/tor/torrc` and replace its content with:
+### 2. Edit your Tor config file, usually located at `/etc/tor/torrc` and replace its content with:
 
 ```
 RunAsDaemon 1
@@ -35,7 +23,7 @@ BridgeRelay 1
 # censors may be scanning the Internet for this port.
 ORPort TODO1
 
-ServerTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
+ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
 
 # Replace "TODO2" with an obfs4 port of your choice.  This port must be
 # externally reachable and must be different from the one specified for ORPort.
@@ -60,7 +48,7 @@ Nickname PickANickname
 
 * Note that both Tor's OR port and its obfs4 port must be reachable. If your bridge is behind a firewall or NAT, make sure to open both ports. You can use [our reachability test](https://bridges.torproject.org/scan/) to see if your obfs4 port is reachable from the Internet.
 
-### 4. Restart tor
+### 3. Restart tor
 
 ```
 sudo semanage port -a -t tor_port_t -p tcp [OR port set earlier, in TODO1]
@@ -68,7 +56,7 @@ sudo semanage port -a -t tor_port_t -p tcp [obfs4 port set earlier, in TODO2]
 systemctl restart tor
 ```
 
-### 5. Monitor your logs (usually in your syslog)
+### 4. Monitor your logs (usually in your syslog)
 
 To confirm your bridge is running with no issues, you should see something like this:
 
@@ -82,7 +70,7 @@ To confirm your bridge is running with no issues, you should see something like 
 [notice] Self-testing indicates your ORPort is reachable from the outside. Excellent. Publishing server descriptor.
 ```
 
-### 6. Final notes
+### 5. Final notes
 
 If you are having troubles setting up your bridge, have a look at [our help
 section](https://community.torproject.org/relay/getting-help/). If


### PR DESCRIPTION
You don't have to build obfs4 from source on Fedora since it is already packaged and installable with dnf.

However I'm not sure if you need run
```
/sbin/restorecon -v `which obfs4proxy`
```
or not. I did not run it and the port seems to be reachable (tested with https://bridges.torproject.org/scan/).

The package also includes a file `/etc/tor/obfs4.torrc` which maybe could be used to simplify the setup process even further.