### PR TITLE
Fix broken links#120

### DIFF
--- a/content/relay-operations/community-resources/eff-tor-legal-faq/contents.lr
+++ b/content/relay-operations/community-resources/eff-tor-legal-faq/contents.lr
@@ -13,7 +13,7 @@ Therefore, please do not act on this information alone; if you have any specific
 
 Also, if you received this document from anywhere besides the EFF web site or https://community.torproject.org/relay/community-resources/eff-tor-legal-faq, it may be out of date. Follow the link to get the latest version.
 
-Got a DMCA notice? Check out our [sample response letter](/relay/community-resources/eff-tor-legal/faq/tor-dmca-response)!
+Got a DMCA notice? Check out our [sample response letter](/relay/community-resources/eff-tor-legal-faq/tor-dmca-response)!
 
 ## General Information
 

--- a/content/relay-operations/community-resources/tor-abuse-templates/contents.lr
+++ b/content/relay-operations/community-resources/tor-abuse-templates/contents.lr
@@ -9,7 +9,7 @@ body:
 # Before You Start
 
 The best way to handle abuse complaints is to set up your exit node so that they are less likely to be sent in the first place.
-Please see [Tips for Running an Exit Node with Minimal Harassment](https://blog.torproject.org/running-exit-node) and [Tor Exit Guidelines](tor-exit-guidelines) for more info, before reading this document.
+Please see [Tips for Running an Exit Node with Minimal Harassment](https://blog.torproject.org/running-exit-node) and [Tor Exit Guidelines](/relay/community-resources/tor-exit-guidelines/) for more info, before reading this document.
 
 Below are a collection of letters you can use to respond to your ISP about their complaint in regards to your Tor exit server.
 

--- a/content/relay-operations/community-resources/tor-exit-guidelines/contents.lr
+++ b/content/relay-operations/community-resources/tor-exit-guidelines/contents.lr
@@ -27,7 +27,7 @@ A good ISP is one that offers cheap bandwidth and is not being used by other mem
 Before you continue, you may ask the Tor community if your choice is a good one.
 We very much need diversity, and it does not help if we pool too many exits at one friendly ISP.
 
-In any case, add the ISP to the [GoodBadISPs](good-bad-isps) page.
+In any case, add the ISP to the [GoodBadISPs](/relay/community-resources/good-bad-isps/) page.
 
 To find an ISP, go through forums and sites where ISPs posts their latest deals, and contact them about Tor hosting.
 Once you identified your ISP, you can follow the two-step advice of TorServers.net.
@@ -77,7 +77,7 @@ If you receive an abuse complaint, don't freak out! Here is some advice for you:
 
 TorServers.net is a fairly large Tor exit operator and we receive only a very small number of complaints, especially compared to the amount of traffic we push. Roughly 80% are automated reports, and the rest is usually satisfied with [our default reply](https://www.torservers.net/wiki/abuse/templates). We have not needed the input of a lawyer in many years of operation following the advice on this page.
 
-In addition to the [templates at Torservers.net](https://www.torservers.net/wiki/abuse/templates), you can find many more templates for various scenarios on the [Tor Abuse Templates](tor-abuse-templates) . It is exceptionally rare to encounter a scenario where none of these templates apply.
+In addition to the [templates at Torservers.net](https://www.torservers.net/wiki/abuse/templates), you can find many more templates for various scenarios on the [Tor Abuse Templates](/relay/community-resources/tor-abuse-templates/) . It is exceptionally rare to encounter a scenario where none of these templates apply.
 
 ### If you receive a threatening letter from a lawyer about abusive use or a DMCA complaint, also don't freak out.
 

--- a/content/relay-operations/community-resources/tor-relay-universities/contents.lr
+++ b/content/relay-operations/community-resources/tor-relay-universities/contents.lr
@@ -26,7 +26,7 @@ Of course, you need to understand that without actual clear precedent (and even 
 In any case, the key here is to become familiar with the laws and their implications and uncertainties.
 
  * Third, learn about Tor's design.
-Read the [design overview](https://2019.www.torproject.org/overview.html), the [design paper](https://www.torproject.org/svn/trunk/doc/design-paper/tor-design.html), and the [FAQ](https://2019.www.torproject.org/docs/faq.html.en).
+Read the [design overview](https://2019.www.torproject.org/overview.html), the [design paper](https://svn-archive.torproject.org/svn/projects/design-paper/tor-design.pdf), and the [FAQ](https://2019.www.torproject.org/docs/faq.html.en).
 Hang out on IRC ([irc.oftc.net](https://www.oftc.net) - #tor-relays) for a while and learn more.
 If possible, attend a talk by one of the Tor developers.
 Learn about the types of people and organizations who need secure communications on the Internet.

--- a/content/relay-operations/relays-requirements/contents.lr
+++ b/content/relay-operations/relays-requirements/contents.lr
@@ -27,7 +27,7 @@ Fast exit relays (>=100 Mbit/s) usually have to handle a lot more concurrent con
 
 It is recommended that a relay have at least 16 Mbit/s (Mbps) upload bandwidth and 16 Mbit/s (Mbps) download bandwidth available for Tor. More is better.
 The minimum requirements for a relay are 10 Mbit/s (Mbps).
-If you have less than 10 Mbit/s but at least 1 Mbit/s we recommend you run a [bridge with obfs4 support](relay/setup/bridge).
+If you have less than 10 Mbit/s but at least 1 Mbit/s we recommend you run a [bridge with obfs4 support](/relay/setup/bridge/).
 If you do not know your bandwidth you can use http://beta.speedtest.net to measure it.
 
 # Monthly Outbound Traffic

--- a/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
+++ b/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
@@ -53,7 +53,7 @@ Enable the following settings:
 
 Confirm your configuration with OK.
 
-The official openSUSE documentation can be found [here](https://doc.opensuse.org/documentation/leap/startup/html/book.opensuse.startup/cha.onlineupdate.you.html#sec.onlineupdate.you.automatically).
+The official openSUSE documentation can be found [here](https://doc.opensuse.org/documentation/leap/startup/single-html/book.opensuse.startup/index.html#sec-onlineupdate-you-automatically).
 ---
 html: two-columns-page.html
 ---

--- a/content/user-research/guidelines/contents.lr
+++ b/content/user-research/guidelines/contents.lr
@@ -58,7 +58,7 @@ It is easier to have this material printed and in hands, but if you prefer, you 
 
 Keep in mind that you might not have a useful Internet in the venue, so if you're going to install a Tor feature with someone during the interview, you may need to have it downloaded before the training.
 
-## Report to Tor UX team 
+## Report to Tor UX team
 Before ending the training, coordinate with the trainer the feedbacks, you two should work together to hand out post-its for the audience, you can give one post-it on each color and ask them to fill it with what they think about: 1. the service they just learned; 2. Tor project; and 3. Tor in general. It can also be questions - keep in mind that every feedback is a good feedback.
 
 It is very important for us to hear back from you. We want to know how the training and the research was for you, how we can improve our support and also, if you want to keep running Tor User Research. We will ask you to fill a form by the end of the research, so we can get your address to send to you a researcher kit (t-shirts and stickers). We hope to hear back from you very soon!

--- a/content/user-research/guidelines/contents.lr
+++ b/content/user-research/guidelines/contents.lr
@@ -58,13 +58,12 @@ It is easier to have this material printed and in hands, but if you prefer, you 
 
 Keep in mind that you might not have a useful Internet in the venue, so if you're going to install a Tor feature with someone during the interview, you may need to have it downloaded before the training.
 
-## Report to Tor UX team
-Before ending the training, coordinate with the trainer the feedbacks, you two should work together to hand out post-its for the audience; you can give one post-it on each color and ask them to fill it with what they think about: 1. the service they just learned; 2. Tor project; and 3. Tor, in general. It can also be questions - keep in mind that every feedback is proper feedback.
+## Report to Tor UX team 
+Before ending the training, coordinate with the trainer the feedbacks, you two should work together to hand out post-its for the audience, you can give one post-it on each color and ask them to fill it with what they think about: 1. the service they just learned; 2. Tor project; and 3. Tor in general. It can also be questions - keep in mind that every feedback is a good feedback.
 
-We must hear back from you. We want to know how the training and the research were for you, how we can improve our support, and also if you're going to keep running Tor User Research. Please, fill out [this form](https://limesurvey), by the end of it, we will also ask your address to send to you a researcher kit (t-shirts and stickers).
-We hope to hear back from you very soon!
+It is very important for us to hear back from you. We want to know how the training and the research was for you, how we can improve our support and also, if you want to keep running Tor User Research. We will ask you to fill a form by the end of the research, so we can get your address to send to you a researcher kit (t-shirts and stickers). We hope to hear back from you very soon!
 
-You can find our document to report [here](https://linkto). But if you think you won't have time to gather and report in this format, we would love to have another way to get the material you collected. You can take pictures or send your 'raw' notes for us.
+We will send you our document on **how to report** to the UX team, so please [get in touch](https://lists.torproject.org/cgi-bin/mailman/listinfo/ux) with us to get it. If you think you won't have time to gather and report in this format, we would love to have another way to get the material you collected. You can take pictures or send your ´raw´ notes for us.
 
 ## Additional links
 


### PR DESCRIPTION
The following broken links have been fixed:

In https://community.torproject.org/relay/community-resources/tor-exit-guidelines, broken links:

- [x] https://community.torproject.org/relay/community-resources/tor-exit-guidelines/good-bad-isps

- [x] https://community.torproject.org/relay/community-resources/tor-exit-guidelines/tor-abuse-templates


In https://community.torproject.org/relay/community-resources/tor-abuse-templates, broken links:


- [x] https://community.torproject.org/relay/community-resources/tor-abuse-templates/tor-exit-guidelines


In https://community.torproject.org/relay/community-resources/tor-relay-universities/, broken link:


- [x] https://www.torproject.org/svn/trunk/doc/design-paper/tor-design.html


In https://community.torproject.org/relay/setup/guard/centosrhel/updates, broken link:

- [x] https://doc.opensuse.org/documentation/leap/startup/html/book.opensuse.startup/cha.onlineupdate.you.html#sec.onlineupdate.you.automatically


In https://community.torproject.org/relay/community-resources/eff-tor-legal-faq/, broken link:


- [x] https://community.torproject.org/relay/community-resources/eff-tor-legal/faq/tor-dmca-response


In https://community.torproject.org/relay/relays-requirements/, broken link:


- [x] https://community.torproject.org/relay/relays-requirements/relay/setup/bridge

As per my discussion with thurayya, the last two links were no longer needed after I was directed to the most recent update of the [User Research Guidelines](https://gitlab.torproject.org/torproject/ux/research/-/blob/master/community/guidelines-ur.md#user-research-guidelines)

In https://community.torproject.org/user-research/guidelines/, broken link:


- [N/A] https://limesurvey/ (ERRNO_ENOTFOUND)

- [N/A] https://linkto/ (ERRNO_ENOTFOUND)