### PR TITLE
Remove open-iconic-bootstrap.css link

### DIFF
--- a/templates/meta.html
+++ b/templates/meta.html
@@ -2,6 +2,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ _('Defend yourself against tracking and surveillance. Circumvent censorship.') }} | {{ this.title }}">
 <link rel="stylesheet" href="{{ '/static/css/bootstrap.css'|asseturl }}">
-<link rel="stylesheet" href="{{ '/static/fonts/open-iconic/font/css/open-iconic-bootstrap.css'|asseturl }}">
 <link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}" rel="stylesheet">
 <title>{{ _("Tor Project") }} | {% block title %}{{ this.title }}{% endblock %}</title>


### PR DESCRIPTION
Concerning:

https://gitlab.torproject.org/torproject/web/community/-/issues/122

the link to the open-iconic-bootstrap stylesheet is deleted.