### PR TITLE
Updates relay operation setup for Fedora/CentOS/RHEL

### DIFF
--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -11,7 +11,23 @@ body:
 * CentOS / RHEL:
 
 ```
-yum install epel-release
+yum install epel-release -y
+```
+
+Then add the following to the `/etc/yum.repos.d/tor.repo` file.
+
+```
+[tor]
+name=Tor for Enterprise Linux $releasever - $basearch
+baseurl=https://rpm.torproject.org/centos/$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.torproject.org/centos/public_gpg.key
+cost=100
+```
+And then install the following packages.
+
+```
 yum install git golang tor policycoreutils-python-utils
 ```
 

--- a/content/relay-operations/technical-setup/bridge/fedora/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/fedora/contents.lr
@@ -8,6 +8,19 @@ body:
 
 ### 1. Install tor and dependencies
 
+Add the following to /etc/yum.repos.d/tor.repo
+
+```
+[tor]
+name=Tor for Fedora $releasever - $basearch
+baseurl=https://rpm.torproject.org/fedora/$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.torproject.org/fedora/public_gpg.key
+cost=100
+```
+Then install tor and the dependencies.
+
 ```
 dnf install git golang tor policycoreutils-python-utils
 ```

--- a/content/relay-operations/technical-setup/guard/centosrhel/contents.lr
+++ b/content/relay-operations/technical-setup/guard/centosrhel/contents.lr
@@ -16,7 +16,17 @@ To install `tor` package on CentOS/RHEL, you need to install the [EPEL](https://
 
 `yum install epel-release`
 
-# 3. Install the tor package and verify the EPEL signing key
+# 3. Add the following to /etc/yum.repos.d/tor.repo and then install the tor package.
+
+```
+[tor]
+name=Tor for Enterprise Linux $releasever - $basearch
+baseurl=https://rpm.torproject.org/centos/$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.torproject.org/centos/public_gpg.key
+cost=100
+```
 
 `yum install tor`
 

--- a/content/relay-operations/technical-setup/guard/fedora/contents.lr
+++ b/content/relay-operations/technical-setup/guard/fedora/contents.lr
@@ -10,9 +10,17 @@ body:
 
 One of the most imported things to keeps your relay secure is to install security updates timely and ideally automatically so you can not forget about it. Follow the instructions to enable [automatic software updates](updates) for your operating system.
 
-# 2.  Install the tor package
+# 2.  # 3. Add the following to /etc/yum.repos.d/tor.repo and then install the tor package.
 
-`dnf install tor`
+```
+[tor]
+name=Tor for Fedora $releasever - $basearch
+baseurl=https://rpm.torproject.org/fedora/$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.torproject.org/fedora/public_gpg.key
+cost=100
+```
 
 # 3. Put the tor configuration file `/etc/tor/torrc` in place
 


### PR DESCRIPTION
It has details on how to install the Tor package from the
rpm.torproject.org repository.

Based on https://support.torproject.org/rpm/