### PR TITLE
Find and fix header with two colors

### DIFF
--- a/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr
@@ -137,8 +137,6 @@ key:
 
 2
 ---
-color: primary
----
 subtitle: How to deploy an obfs4 bridge on CentOS / RHEL / OpenSUSE
 ---
 _template: layout.html

--- a/content/relay-operations/technical-setup/bridge/fedora/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/fedora/contents.lr
@@ -109,8 +109,6 @@ key:
 
 2
 ---
-color: primary
----
 subtitle: How to deploy an obfs4 bridge on Fedora
 ---
 _template: layout.html

--- a/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/openbsd/contents.lr
@@ -2,6 +2,8 @@ _model: page
 ---
 title: OpenBSD
 ---
+color: primary
+---
 html: two-columns-page.html
 ---
 key: 4

--- a/content/relay-operations/technical-setup/exit/contents.lr
+++ b/content/relay-operations/technical-setup/exit/contents.lr
@@ -2,6 +2,8 @@ _model: page
 ---
 title: Exit
 ---
+color: primary
+---
 html: two-columns-page.html
 ---
 section: relay operations

--- a/content/user-research/become-tester/contents.lr
+++ b/content/user-research/become-tester/contents.lr
@@ -4,6 +4,8 @@ section_id: user-research
 ---
 title: Become a Tester
 ---
+color: primary
+---
 subtitle: We regularly release Tor Browser early versions to allow users to test software improvements and new ideas. Sign up to be in our testing pool.
 ---
 key: 1


### PR DESCRIPTION
# Regarding Issue

[Find and fix header with two colors](https://gitlab.torproject.org/torproject/web/community/-/issues/129)

-----

# Fix

Added `color: primary` to the following files:

* `/community/content/relay-operations/technical-setup/bridge/openbsd/contents.lr`

* `/community/content/relay-operations/technical-setup/exit/contents.lr`

* `/community/content/user-research/become-tester/contents.lr`

Deleted redundant `color: primary` in the following files:

* `/community/content/relay-operations/technical-setup/bridge/centos-rhel-opensuse/contents.lr`

* `/community/content/relay-operations/technical-setup/bridge/fedora/contents.lr`