### PR TITLE
Update pluggable transport link

### DIFF
--- a/content/relay-operations/types-of-relays/contents.lr
+++ b/content/relay-operations/types-of-relays/contents.lr
@@ -60,7 +60,7 @@ Tor bridges are nodes in the network that are not listed in the public Tor direc
 
 Bridges are useful for Tor users under oppressive regimes or for people who want an extra layer of security because they're worried somebody will recognize that they are contacting a public Tor relay IP address.
 Several countries, including China and Iran, have found ways to detect and block connections to Tor bridges.
-[Pluggable transports](https://2019.www.torproject.org/docs/pluggable-transports.html.en), a special kind of bridge, address this by adding an additional layer of obfuscation.
+[Pluggable transports](https://tb-manual.torproject.org/circumvention/), a special kind of bridge, address this by adding an additional layer of obfuscation.
 
 Bridges are relatively easy, low-risk and low bandwidth Tor nodes to operate, but they have a big impact on users.
 A bridge isn't likely to receive any abuse complaints, and since bridges are not listed in the public consensus, they are unlikely to be blocked by popular services.


### PR DESCRIPTION
# Regarding Issue
[Pluggable Transport Links to 2019 Site Instead of TB-Manual](https://gitlab.torproject.org/tpo/web/community/-/issues/140)

# Fix
In the [`content/relay-operations/types-of-relays/contents.lr file`](https://gitlab.torproject.org/tpo/web/community/-/blob/master/content/relay-operations/types-of-relays/contents.lr), on line 63 change

```
[Pluggable transports](https://2019.www.torproject.org/docs/pluggable-transports.html.en)
```

to

```
[Pluggable transports](https://tb-manual.torproject.org/circumvention/)
```