### PR TITLE
Add instructions for Caddy 2

### DIFF
--- a/content/onion-services/advanced/onion-location/contents.lr
+++ b/content/onion-services/advanced/onion-location/contents.lr
@@ -209,7 +209,7 @@ file_server
 **Testing it out:** Test it out with:
 
 ```
-curl -I https://your-website.tld
+curl --head https://your-website.tld
 ```
 
 and look for the `onion-location` line.

--- a/content/onion-services/advanced/onion-location/contents.lr
+++ b/content/onion-services/advanced/onion-location/contents.lr
@@ -184,6 +184,36 @@ To test if the Onion-Location is working, fetch the web site HTTP headers, for e
 Look for `onion-location` entry and the onion service address.
 Or, open the web site in Tor Browser and a purple pill will appear in the address bar.
 
+### Caddy
+
+Caddy features [automatic HTTPS](https://caddyserver.com/docs/automatic-https)
+by default, so it provisions your TLS certificate and takes care of
+HTTP-to-HTTPS redirection for you. If you're using Caddy 2, to include an
+Onion-Location header, add the following declaration in your Caddyfile:
+
+```
+header Onion-Location http://<your-onion-address>.onion{path}
+```
+
+If you're running a static site and have the onion address in a `$TOR_HOSTNAME`
+environment variable, your Caddyfile will look like this:
+
+```
+your-website.tld
+
+header Onion-Location http://{$TOR_HOSTNAME}{path}
+root * /var/www
+file_server
+```
+
+**Testing it out:** Test it out with:
+
+```
+curl -I https://your-website.tld
+```
+
+and look for the `onion-location` line.
+
 ### Using an HTML `<meta>` attribute
 
 The identical behaviour of Onion-Location includes the option of defining it as a HTML `<meta>` http-equiv attribute.


### PR DESCRIPTION
The documentation was missing instructions for Caddy 2, which is the most painless way to run add an `onion-locator`. Caddy 2 automatically provisions SSL/TLS certificate via LetsEncrypt and runs the HTTP-to-HTTPS redirect by default, both of which are requirements for the Onion Location header.