### PR TITLE
fix consistency of onion terminology

### DIFF
--- a/content/gsoc/onion-toolbox/contents.lr
+++ b/content/gsoc/onion-toolbox/contents.lr
@@ -37,7 +37,7 @@ body:
 
 It is not necessarily difficult to use onion services, but it might be tricky to configure a web service to be offered via .onion so that it doesn’t leak sensitive information.
 
-There are detailed [guides](https://riseup.net/en/security/network-security/tor/onionservices-best-practices) available for users that would like to offer a web application via .onion and some tools have been developed to help service operators: discover known misconfiguration or [vulnerabilities](https://onionscan.org/) or deploy an [onion site](https://github.com/alecmuffett/eotk).
+There are detailed [guides](https://riseup.net/en/security/network-security/tor/onionservices-best-practices) available for users that would like to offer a web application via .onion and some tools have been developed to help service operators: discover known misconfiguration or [vulnerabilities](https://onionscan.org/) or deploy a [.onion site](https://github.com/alecmuffett/eotk).
 
 Involving a wider developer community can help creating a better image of Tor and onion services, replacing the “dark net” narrative with the secure and private web one.
 
@@ -49,7 +49,7 @@ Ultimately myonion is about creating a better experience for onion services deve
 
 Myonion is a developer tool box, providing a command line interface and a GUI to configure and deploy existing services via .onion. A minimal prototype for myonion already [exists](https://github.com/hiromipaw/myonion).
 
-Someone that may want to run an onion service can use the myonion wrapper app to start a .onion from their computer and sharea static website or a web application.
+Someone that may want to run an onion service can use the myonion wrapper app to start a .onion from their computer and share a static website or a web application.
 
 Myonion can also be used to deploy the resulting configured app to a defined set of cloud providers.
 

--- a/content/onion-services/advanced/onion-location/contents.lr
+++ b/content/onion-services/advanced/onion-location/contents.lr
@@ -8,7 +8,7 @@ _template: layout.html
 ---
 title: Onion-Location
 ---
-subtitle: Learn how to set up an Onion-Location for your onion site.
+subtitle: Learn how to set up an Onion-Location for your .onion site.
 ---
 key: 1
 ---
@@ -16,14 +16,14 @@ html: two-columns-page.html
 ---
 body:
 
-Onion-Location is an easy way to advertise an onion site to the users.
+Onion-Location is an easy way to advertise a .onion site to the users.
 You can either configure a web server to show an Onion-Location Header or add an HTML meta attribute in the website.
 
 For the header to be valid the following conditions need to be fulfilled:
 
  * The Onion-Location value must be a valid URL with http: or https: protocol and a .onion hostname.
  * The webpage defining the Onion-Location header must be served over HTTPS.
- * The webpage defining the Onion-Location header must not be an onion site.
+ * The webpage defining the Onion-Location header must not be a .onion site.
 
 In this page, the commands to manage the web server are based Debian-like operating systems and may differ from other systems.
 Check your web server and operating system documentation.

--- a/content/onion-services/advanced/opsec/contents.lr
+++ b/content/onion-services/advanced/opsec/contents.lr
@@ -27,6 +27,6 @@ This leaks information to an observant adversary.
  - It is generally a better idea to host onion services on a Tor client rather than a Tor relay, since relay uptime and other properties are publicly visible.
  - The longer an onion service is online, the higher the risk that its location is discovered.
 The most prominent attacks are building a profile of the onion service's availability and matching induced traffic patterns.
- - Another common issue is whether to use HTTPS on your onionsite or not.
+ - Another common issue is whether to use HTTPS on your .onion site or not.
 Have a look at [this post](https://blog.torproject.org/blog/facebook-hidden-services-and-https-certs) on the Tor Blog to learn more about these issues.
  - To protect your onion service from advanced attacks you should use [Vanguards addon](https://github.com/mikeperry-tor/vanguards), read [Tor blog about Vanguards](https://blog.torproject.org/announcing-vanguards-add-onion-services) and [Vanguards' Security README](https://github.com/mikeperry-tor/vanguards/blob/master/README_SECURITY.md).


### PR DESCRIPTION
issue: https://gitlab.torproject.org/tpo/web/community/-/issues/60

standardised usage of ".onion site" to refer to websites using onion services, also added a space where needed to fix grammar