### PR TITLE
Update contents.lr

### DIFF
--- a/content/relay-operations/technical-setup/guard/debianubuntu/updates/contents.lr
+++ b/content/relay-operations/technical-setup/guard/debianubuntu/updates/contents.lr
@@ -19,12 +19,12 @@ apt-get install unattended-upgrades apt-listchanges
 Put the lines below into the configuration file /etc/apt/apt.conf.d/50unattended-upgrades, everything that was originally inside the generated file can be removed before you add the lines below.
 
 ```
-    Unattended-Upgrade::Origins-Pattern {
-            "origin=Debian,codename=${distro_codename},label=Debian-Security";
-    	"origin=TorProject";
-    };
-    Unattended-Upgrade::Package-Blacklist {
-    };
+Unattended-Upgrade::Origins-Pattern {
+    "origin=Debian,codename=${distro_codename},label=Debian-Security";
+    "origin=TorProject";
+};
+Unattended-Upgrade::Package-Blacklist {
+};
 ```
 
 #3. Automatically reboot
@@ -32,14 +32,16 @@ Put the lines below into the configuration file /etc/apt/apt.conf.d/50unattended
 If you want to automatically reboot add the following at the the end of the file `/etc/apt/apt.conf.d/50unattended-upgrades`:
 
 ```
-    Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot "true";
+```
 
-    Create the file /etc/apt/apt.conf.d/20auto-upgrades with the following content
+Update the file `/etc/apt/apt.conf.d/20auto-upgrades` with the following content
 
-    APT::Periodic::Update-Package-Lists "1";
-    APT::Periodic::AutocleanInterval "5";
-    APT::Periodic::Unattended-Upgrade "1";
-    APT::Periodic::Verbose "1";
+```
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::AutocleanInterval "5";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Verbose "1";
 ```
 
 # 4. Test
@@ -47,7 +49,7 @@ If you want to automatically reboot add the following at the the end of the file
 You can test your unattended-upgrades setup with the following command:
 
 ```
-   sudo unattended-upgrade -d
+sudo unattended-upgrade -d
 ```
 ---
 html: two-columns-page.html


### PR DESCRIPTION
1. Reformat the config

    No leading spaces in the config provided

2. Fix an error in the *automatically reboot* session

    Updating `/etc/apt/apt.conf.d/20auto-upgrades` should be another step, not part of the `/etc/apt/apt.conf.d/50unattended-upgrades`. 

    In Ubuntu 20.04, the `/etc/apt/apt.conf.d/20auto-upgrades` is already created, we can update it without recreating it. So I change the wording from `Create` to `Update`