### PR TITLE
Update contents.lr

### DIFF
--- a/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
+++ b/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
@@ -29,9 +29,8 @@ Put the configuration file `/etc/tor/torrc` in place:
 #change the nickname "myNiceRelay" to a name that you like
 Nickname myNiceRelay
 ORPort 443
-ExitRelay 0
 SocksPort 0
-ControlSocket 0
+ControlPort 0
 # Change the email address below and be aware that it will be published
 ContactInfo tor-operator@your-emailaddress-domain
 ```

--- a/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
+++ b/content/relay-operations/technical-setup/guard/debianubuntu/contents.lr
@@ -29,6 +29,7 @@ Put the configuration file `/etc/tor/torrc` in place:
 #change the nickname "myNiceRelay" to a name that you like
 Nickname myNiceRelay
 ORPort 443
+ExitRelay 0
 SocksPort 0
 ControlPort 0
 # Change the email address below and be aware that it will be published


### PR DESCRIPTION
Update key from `ControlSocket`  to `ControlPort`
    There is a key called `ControlPort` in Tor 0.4.4.6 but not `ControlSocket`