### PR TITLE
Add instruction on enable autoupdate in RHEL 8

### DIFF
--- a/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
+++ b/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
@@ -6,9 +6,35 @@ title: RPM Distributions
 ---
 body:
 
-# CentOS and RHEL
+# CentOS and RHEL 8 or later versions
 
-For CentOS and RHEL the yum-cron package is the preferred approach:
+For CentOS and RHEL 8 or earlier versions, the dnf-automatic package is the preferred approach:
+
+```
+dnf install dnf-automatic
+```
+
+In /etc/dnf/automatic.conf set:
+
+```
+download_updates = yes
+apply_updates = yes
+```
+
+Enable and start automatic updates via:
+
+```
+systemctl enable --now dnf-automatic.timer
+```
+
+Check status of dnf-automatic:
+```
+systemctl list-timers *dnf-*
+```
+
+# CentOS and RHEL 7 or earlier versions
+
+For CentOS and RHEL 7 or earlier versions, the yum-cron package is the preferred approach:
 
 ```
 yum install yum-cron

--- a/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
+++ b/content/relay-operations/technical-setup/guard/centosrhel/updates/contents.lr
@@ -8,7 +8,7 @@ body:
 
 # CentOS and RHEL 8 or later versions
 
-For CentOS and RHEL 8 or earlier versions, the dnf-automatic package is the preferred approach:
+For CentOS and RHEL 8 or later versions, the dnf-automatic package is the preferred approach:
 
 ```
 dnf install dnf-automatic


### PR DESCRIPTION
The tool for auto upgrade is changed from `yum-cron` to `dnf-automatic` in RHEL 8/ CentOS 8/ Fedora22.

A session on how to setup `dnf-automatic` in RHEL 8/ CentOS 8 is added, which is based on https://fedoraproject.org/wiki/AutoUpdates#Fedora_22_or_later_versions