### PR TITLE
Add Focal Fossa as supported release in how to install obfs4proxy

### DIFF
--- a/content/relay-operations/technical-setup/bridge/debian-ubuntu/contents.lr
+++ b/content/relay-operations/technical-setup/bridge/debian-ubuntu/contents.lr
@@ -15,7 +15,7 @@ Get the latest version of Tor. If you're on Debian stable, `sudo apt-get install
 ### 2. Install obfs4proxy
 
 On [Debian](https://packages.debian.org/search?keywords=obfs4proxy), the `obfs4proxy` package is available in unstable, testing, and stable.
-On [Ubuntu](https://packages.ubuntu.com/search?keywords=obfs4proxy), bionic, cosmic, disco, and eoan have the package.
+On [Ubuntu](https://packages.ubuntu.com/search?keywords=obfs4proxy), bionic, cosmic, disco, eoan, and focal have the package.
 If you're running any of them, `sudo apt-get install obfs4proxy` should work.
 
 If not, you can [build it from source](https://gitlab.com/yawning/obfs4#installation).


### PR DESCRIPTION
Added to the docs that Ubuntu focal supports obfs4proxy package installation. 

Addressing the issue : https://gitlab.torproject.org/tpo/web/community/-/issues/185