### PR TITLE
Added parentheses

### DIFF
--- a/templates/outreach-talk.html
+++ b/templates/outreach-talk.html
@@ -52,7 +52,7 @@
             <span class="display-4 text-primary">
               <i class="fas fa-hand-holding-heart pb-4"></i>
             </span>
-            <h2 class="card-title">{{ _('Tor software is developed by the Tor Project, a 501(c)3 nonprofit organization.') }}</h2>
+            <h2 class="card-title">{{ _('Tor software is developed by the Tor Project, a 501(c)(3) nonprofit organization.') }}</h2>
             <p class="card-text">{{ _('We build free and open source software anyone can use.') }}</p>
           </div>
         </div>


### PR DESCRIPTION
Addressing the issue : Parentheses missing in definition of "501(c)(3) nonprofit organization"