### PR TITLE
Added Hyperlinks

### DIFF
--- a/content/relay-operations/getting-help/contents.lr
+++ b/content/relay-operations/getting-help/contents.lr
@@ -6,9 +6,9 @@ title: Getting help
 ---
 body:
 
-If you run into problems while setting up your relay, you can ask your questions on the public [tor-relays mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-relays).  The list is a great resource for asking (and answering) questions, and for getting to know other relay operators. Make sure to check out the archives!
+If you run into problems while setting up your relay, you can ask your questions on the public [tor-relays mailing list](https://lists.torproject.org/cgi-bin/mailman/listinfo/tor-relays).  The list is a great resource for asking (and answering) questions, and for getting to know other relay operators. Make sure to check out the [archives](https://lists.torproject.org/pipermail/tor-relays/)!
 
-You can also get help by joining the IRC channel #tor-relays in the network [irc.oftc.net](https://support.torproject.org/get-in-touch/#irc-help).
+You can also get help by joining the IRC channel #tor-relays in the network [irc.oftc.net](https://webchat.oftc.net/?channels=tor-relays).
 
 ---
 html: two-columns-page.html


### PR DESCRIPTION
Issue #167 in community: [Relay Operations][Getting Help] Add hyperlinks to IRC channel (OFTC webchat) and mailing-list archive