### PR TITLE
More user friendly output of IP addresses

### DIFF
--- a/content/relay/setup/post-install/contents.lr
+++ b/content/relay/setup/post-install/contents.lr
@@ -97,7 +97,7 @@ Note: You have to explicitly specify your IPv6 address in square brackets, you c
 If you have a global IPv6 address you should be able to find it in the output of the following command:
 
 ```
-ip addr|grep inet6|grep global;echo "Remove /xx suffix from the address"
+ip -6 addr | grep global | sed 's/inet6//;s#/.*##'
 ```
 
 If you are an exit relay with IPv6 connectivity, tell your tor daemon to allow exiting via IPv6 so clients can reach IPv6 destinations:

--- a/content/relay/setup/post-install/contents.lr
+++ b/content/relay/setup/post-install/contents.lr
@@ -97,7 +97,7 @@ Note: You have to explicitly specify your IPv6 address in square brackets, you c
 If you have a global IPv6 address you should be able to find it in the output of the following command:
 
 ```
-ip addr|grep inet6|grep global
+ip addr|grep inet6|grep global;echo "Remove /xx suffix from the address"
 ```
 
 If you are an exit relay with IPv6 connectivity, tell your tor daemon to allow exiting via IPv6 so clients can reach IPv6 destinations:


### PR DESCRIPTION
In my case it outputs three IPv6 and it does not work, i had to remove /xx suffix from the address - which is not friendly to beginer users. I have not tried if ORPort 9001 works if this port is used by IPv4 already, personally i used "auto" instead of "9001"

If anyone knows better command to output main IPv6 in correct format, please modify it,
ideas:
1)
`ip -6 addr | grep inet6 | awk -F '[ \t]+|/' '{print $3}' | grep -v ^::1 | grep -v ^fe80`
list all interfaces IPv6 in correct (torrc acceptable) format, suffixing by "|head -n1" may list the actual main interface IPv6
2)
`grep inet6 -A 1 /etc/network/interfaces|grep address`
(not sure how universal is this command)
