### PR TITLE
Change tor log path under bridge setup - Debian/Ubuntu

### DIFF
--- a/content/relay/setup/bridge/debian-ubuntu/contents.lr
+++ b/content/relay/setup/bridge/debian-ubuntu/contents.lr
@@ -67,7 +67,7 @@ Don't forget to change the `ORPort`, `ServerTransportListenAddr`, `ContactInfo`,
 
 ### 5. Monitor your logs
 
-To confirm your bridge is running with no issues, you should see something like this (usually in `/var/log/tor/log` or `/var/log/syslog`):
+To confirm your bridge is running with no issues, you should see something like this (usually in `/var/log/tor/notices.log` or `/var/log/syslog`):
 
 
 ```


### PR DESCRIPTION
Change the tor log path in section '### 5. Monitor your logs' from `/var/log/tor/log` to `/var/log/tor/notices.log` as the first does not point to an existing file.