### PR TITLE
Add path to identity keys on OpenBSD

### DIFF
--- a/content/relay/setup/post-install/contents.lr
+++ b/content/relay/setup/post-install/contents.lr
@@ -120,6 +120,7 @@ Default locations of the keys folder:
 
 * Debian/Ubuntu: `/var/lib/tor/keys`
 * FreeBSD: `/var/db/tor/keys`
+* OpenBSD: `/var/tor/keys`
 * Fedora: `/var/lib/tor/keys`
 
 ## Subscribe to the tor-announce mailing list


### PR DESCRIPTION
I'm on OpenBSD 7.0. Tor package maintained by OpenBSD.