### PR TITLE
Add backslashes to the /etc/login.conf snippet

### DIFF
--- a/content/relay/setup/guard/openbsd/contents.lr
+++ b/content/relay/setup/guard/openbsd/contents.lr
@@ -59,8 +59,8 @@ By default, OpenBSD maintains a rather low limit on the maximum number of open f
 Append the following section to `/etc/login.conf`:
 
 ```
-tor:
-    :openfiles-max=13500:
+tor:\
+    :openfiles-max=13500:\
     :tc=daemon:
 ```
 


### PR DESCRIPTION
The backslashes are necessary for those settings to apply. Tested on OpenBSD 7.0, Tor 0.4.6.7.

The [doc/TUNING](https://gitweb.torproject.org/tor.git/tree/doc/TUNING?h=release-0.4.6) file is correct.