### PR TITLE
consistency to DragonFlyBSD/FreeBSD/HardenedBSD pkg updates

### DIFF
--- a/content/relay/setup/guard/freebsd/updates/contents.lr
+++ b/content/relay/setup/guard/freebsd/updates/contents.lr
@@ -19,7 +19,7 @@ Let's use `/root/bin/pkg-upgrade.sh` for our setup. This is how is must look lik
 ```
 #!/bin/sh
 PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
-RAND=$(jot -r 1 300)
+RAND=$(jot -r 1 900)
 ENV="BATCH=yes IGNORE_OSVERSION=yes"
 sleep ${RAND}
 env ${ENV} pkg update -q -f && \
@@ -27,13 +27,17 @@ env ${ENV} pkg upgrade -q -U -y --fetch-only && \
 env ${ENV} HANDLE_RC_SCRIPTS=yes pkg upgrade -q -U -y
 ```
 
-### 2. Schedule the Job
+### 2. Schedule a `cron` Job
+
+For this particular schedule we opt to run the script every 0h00 (depending on your timezone), and will trigger the packages updates process itself depending on the value set to the `$RAND` variable - it's configured to produce a **sleep** between 0 and 900 seconds (15 minutes).
 
 ```
-# echo "0 0 * * * root /bin/sh /root/pkg_upgrade.sh >/dev/null" >> /etc/crontab
+# echo "0 0 * * * root /bin/sh /root/bin/pkg-upgrade.sh" > /etc/cron.d/pkg-upgrade
 ```
 
-#3. Restart cron's service.
+### 3. Restart `cron`
+
+Finally, restart the `cron` daemon to make configuration changes be used.
 
 ```
 # service cron restart

--- a/content/relay/setup/guard/freebsd/updates/contents.lr
+++ b/content/relay/setup/guard/freebsd/updates/contents.lr
@@ -8,7 +8,7 @@ _slug: updates
 ---
 body:
 
-This guide should work for any DragonFlyBSD, FreeBSD, or  HardenedBSD operating system. It covers _ONLY_ packages updates/upgrades, and does not apply any other patch to base system or kernel.
+This guide should work for DragonFlyBSD, FreeBSD, and HardenedBSD operating system. It covers _ONLY_ packages updates/upgrades, and does not apply any other patch to base system or kernel.
 
 **NOTE:** All steps documented on this page are considering that your server is dedicated to provide a Tor (bridge/guard/exit) relay service. Please be aware that _services will be restarted_ during the automatic software update process documented here.
 

--- a/content/relay/setup/guard/freebsd/updates/contents.lr
+++ b/content/relay/setup/guard/freebsd/updates/contents.lr
@@ -1,6 +1,6 @@
 _model: page
 ---
-title: *BSD
+title: DragonFlyBSD / FreeBSD / HardenedBSD
 ---
 color: primary
 ---
@@ -8,23 +8,26 @@ _slug: updates
 ---
 body:
 
-# DragonFlyBSD / FreeBSD / HardenedBSD
+This guide should work for any DragonFlyBSD, FreeBSD, or  HardenedBSD operating system. It covers _ONLY_ packages updates/upgrades, and does not apply any other patch to base system or kernel.
 
-**NOTE:** _all steps documented on this page are considering that your machine/server/system only provides Tor relay services. please be aware that other services running might stop/restart during the upgrade._
+**NOTE:** All steps documented on this page are considering that your server is dedicated to provide a Tor (bridge/guard/exit) relay service. Please be aware that _services will be restarted_ during the automatic software update process documented here.
 
-#1. Create the script to perform the updates.
+### 1. Create the Update Script
 
-Let's use `/root/pkg_upgrade.sh`
+Let's use `/root/bin/pkg-upgrade.sh` for our setup. This is how is must look like:
 
 ```
-#!/usr/bin/env sh
-PATH="/bin:/usr/bin:/sbin:/usr/sbin"
+#!/bin/sh
+PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 RAND=$(jot -r 1 300)
+ENV="BATCH=yes IGNORE_OSVERSION=yes"
 sleep ${RAND}
-env AUTOCLEAN=YES ASSUME_ALWAYS_YES=YES HANDLE_RC_SCRIPTS=YES pkg upgrade
+env ${ENV} pkg update -q -f && \
+env ${ENV} pkg upgrade -q -U -y --fetch-only && \
+env ${ENV} HANDLE_RC_SCRIPTS=yes pkg upgrade -q -U -y
 ```
 
-#2. Schedule the job to run.
+### 2. Schedule the Job
 
 ```
 # echo "0 0 * * * root /bin/sh /root/pkg_upgrade.sh >/dev/null" >> /etc/crontab

--- a/content/relay/setup/guard/freebsd/updates/contents.lr
+++ b/content/relay/setup/guard/freebsd/updates/contents.lr
@@ -35,6 +35,8 @@ For this particular schedule we opt to run the script every 0h00 (depending on y
 # echo "0 0 * * * root /bin/sh /root/bin/pkg-upgrade.sh" > /etc/cron.d/pkg-upgrade
 ```
 
+  * If you want to change the scheduled execution of the update script, configure your [crontab settings](https://crontab.guru/) to a value you would like to use.
+
 ### 3. Restart `cron`
 
 Finally, restart the `cron` daemon to make configuration changes be used.


### PR DESCRIPTION
by merging this request, we would be able to:

  - set the proper title to the "software updates" page related to BSD systems;
    - DragonFlyBSD;
    - FreeBSD;
    - HardenedBSD;
  - use a cleaner and stable version of `pkg-upgrade.sh`;
  - split `pkg upgrade` to all its respective update and upgrade commands (for better understanding);
  - mention a way people can set their own schedule.