### PR TITLE
add new recommendations to DNS on Exit Relays section

### DIFF
--- a/content/relay/setup/exit/contents.lr
+++ b/content/relay/setup/exit/contents.lr
@@ -72,6 +72,7 @@ DNS resolution on exit relays is crucial for Tor clients and it should be reliab
     * If you want to add a second DNS resolver as a fallback to your /etc/resolv.conf configuration, choose a resolver within your autonomous system and make sure that it is not your first entry in that file (the first entry should be your local resolver).
     * If a local resolver like unbound is not an option for you, use a resolver that your provider runs in the same autonomous system (to find out if an IP address is in the same AS as your relay, you can look it up using [bgp.he.net](https://bgp.he.net)).
 * Avoid adding more than two resolvers to your /etc/resolv.conf file to limit AS-level exposure of DNS queries.
+* ensure your local resolver does not use any outbound source IP address that is used by any tor exit or non-exits, because it is not uncommon that tor IPs are (temporarily) blocked and a blocked DNS resolver source IP address can have a broad impact. For unbound you can use the "outgoing-interface" option to specify the source IP addresses for contacting other DNS servers.
 
 There are multiple options for DNS server software. [Unbound](https://nlnetlabs.nl/projects/unbound/about/) has become
 a popular one but feel free to use any other software that you are comfortable with.

--- a/content/relay/setup/exit/contents.lr
+++ b/content/relay/setup/exit/contents.lr
@@ -73,6 +73,11 @@ DNS resolution on exit relays is crucial for Tor clients and it should be reliab
     * If a local resolver like unbound is not an option for you, use a resolver that your provider runs in the same autonomous system (to find out if an IP address is in the same AS as your relay, you can look it up using [bgp.he.net](https://bgp.he.net)).
 * Avoid adding more than two resolvers to your /etc/resolv.conf file to limit AS-level exposure of DNS queries.
 * ensure your local resolver does not use any outbound source IP address that is used by any tor exit or non-exits, because it is not uncommon that tor IPs are (temporarily) blocked and a blocked DNS resolver source IP address can have a broad impact. For unbound you can use the "outgoing-interface" option to specify the source IP addresses for contacting other DNS servers.
+* large exit operators (>=100 Mbit/s) should make an effort to monitor and optimize tor's DNS resolution timeout rate. This can be achieved via tor's prometheus exporter (MetricsPort). The following metric can be used to monitor the timeout rate as seen by tor.
+
+```
+tor_relay_exit_dns_error_total{reason="timeout"} 0
+```
 
 There are multiple options for DNS server software. [Unbound](https://nlnetlabs.nl/projects/unbound/about/) has become
 a popular one but feel free to use any other software that you are comfortable with.


### PR DESCRIPTION

- use a dedicated source IP for DNS resolutions (do not share with tor IPs)
- use prometheus/MetricsPort for monitoring