### PR TITLE
Update post-install to correct FreeBSD location.

### DIFF
--- a/content/relay/setup/bridge/post-install/contents.lr
+++ b/content/relay/setup/bridge/post-install/contents.lr
@@ -8,7 +8,7 @@ Congrats!
 
 If you get to this point, it means that your obfs4 bridge is running and is being distributed by BridgeDB to censored users. Note that it can take several days or weeks until you see a consistent set of users, so don't get discouraged if you don't see user connections right away. BridgeDB uses four buckets for bridge distribution: HTTPS, Moat, Email, and manual. Some buckets are used more than others, which also affects the time until your bridge sees users. Finally, there aren't many bridge users out there, so you cannot expect your bridge to be as popular as a relay.
 
-If you want to connect to your bridge manually, you will need to know the bridge's obfs4 certificate. See the file `/var/lib/tor/pt_state/obfs4_bridgeline.txt` and paste the entire bridge line into Tor Browser:
+If you want to connect to your bridge manually, you will need to know the bridge's obfs4 certificate. This is in the file `obfs4_bridgeline.txt`, which is found in `/var/lib/tor/pt_state/` (or `/var/db/tor/pt_state/` for FreeBSD). Paste the entire bridge line into Tor Browser:
 
 ```
 Bridge obfs4 <IP ADDRESS>:<PORT> <FINGERPRINT> cert=<CERTIFICATE> iat-mode=0


### PR DESCRIPTION
For FreeBSD it seems it's now /var/db/tor/pt_state/obfs4_bridgeline.txt, not /var/lib/tor/pt_state/